### PR TITLE
Prevent length mismatch of trigger and value

### DIFF
--- a/lua/abbreinder.lua
+++ b/lua/abbreinder.lua
@@ -106,6 +106,10 @@ local function close_all_reminders()
     end
 end
 
+local function ltrim(s)
+  return s:match'^%s*(.*)'
+end
+
 -- @param abbr {trigger, value, row, col, col_end, on_change}
 local function output_reminders(abbr_data)
     local buf = vim.api.nvim_get_current_buf()
@@ -115,7 +119,11 @@ local function output_reminders(abbr_data)
     end
 
     -- case of people using abbreviations to correct typos
-    if #abbr_data.trigger == #abbr_data.value then
+    --
+    -- remove trailing whitespace from abbreviation, to avoid cases where this
+    -- causes a length mismatch.
+    trimmed_abbr = ltrim(abbr_data.value)
+    if #abbr_data.trigger == #trimmed_abbr then
         return
     end
 


### PR DESCRIPTION
I'm opening this PR mostly to show some sample code that addresses the issue (in a rudimentary fashion), to have something concrete to discuss. I consider this code to be **neither** ready to merge **nor** likely the appropriate way of implementing a fix. This is all presuming that there is a problem and that it's not just a question of me configuring something incorrectly.

The README states the following:

    Does not trigger if the trigger is the same length as the value, so that abbreviations that correct typos do not remind of incorrect spelling.

The values in `abbr_data.value` seem to be preceded by whitespace. This whitespace causes the length of these values to be one character longer than that of `abbr_data.trigger`.

## For review

1. I have not investigated closely why there's a difference in whitespace. It would be nice to hear if there's something I don't understand about how the plugin works.
1. If the general idea of this PR is sound, then maybe it would be more appropriate to incorporate this change somehow into the `abbremand.nvim` plugin instead. I don't know if this is the case, would defer to the plugin author for this.
